### PR TITLE
Fix errors when compiling with servo support

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -236,6 +236,8 @@ CXXSRC += Action.cpp GuiAction.cpp AutoLevelManager.cpp OffsetManager.cpp Storag
 
 CXXSRC += Marlin_main.cpp MarlinSerial.cpp SDCache.cpp
 
+CXXSRC += Servo.cpp
+
 
 # Define all object files.
 OBJ = ${patsubst %.c,$(BUILD_DIR)/%.o,${CSRC}}


### PR DESCRIPTION
With autobedlevel enabled on prusa i3 hephestos (1st gen). However after send G28 gcode command the encoder stop working. Display and serial interface still working fine.
